### PR TITLE
Added secrets management - put revenueCat api key into secrets config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,7 @@ GoogleService-Info.plist
 ./Tanga/GoogleService-Info.plist
 Tanga/GoogleService-Info.plist
 
-# End of https://www.toptal.com/developers/gitignore/api/swift,xcode
+### Secrets ###
+./Tanga/Secrets.xcconfig
+./Tanga/Secrets/Secrets.xcconfig
+Secrets.xcconfig

--- a/Tanga.xcodeproj/project.pbxproj
+++ b/Tanga.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		980A09692D450A0F00DE2CBA /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 980A09682D450A0F00DE2CBA /* Secrets.xcconfig */; };
 		980DBAA32CB0250600141DA3 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 980DBAA22CB0250600141DA3 /* FirebaseAnalytics */; };
 		980DBAA52CB0250600141DA3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 980DBAA42CB0250600141DA3 /* FirebaseAuth */; };
 		980DBAA72CB0250600141DA3 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 980DBAA62CB0250600141DA3 /* FirebaseCore */; };
@@ -42,6 +43,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		980A09682D450A0F00DE2CBA /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		9840A6FC2CA05A5700194500 /* Tanga.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tanga.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9840A70D2CA05A5800194500 /* TangaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TangaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9840A7172CA05A5800194500 /* TangaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TangaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -128,6 +130,7 @@
 		9840A6F32CA05A5700194500 = {
 			isa = PBXGroup;
 			children = (
+				980A09682D450A0F00DE2CBA /* Secrets.xcconfig */,
 				98A0563E2CC4049300D45063 /* README.md */,
 				9840A6FE2CA05A5700194500 /* Tanga */,
 				9840A7102CA05A5800194500 /* TangaTests */,
@@ -287,6 +290,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				980A09692D450A0F00DE2CBA /* Secrets.xcconfig in Resources */,
 				98A0563F2CC4049B00D45063 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -463,6 +467,7 @@
 		};
 		9840A7222CA05A5800194500 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 980A09682D450A0F00DE2CBA /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -505,6 +510,7 @@
 		};
 		9840A7232CA05A5800194500 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 980A09682D450A0F00DE2CBA /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Tanga.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tanga.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1c79f59e1fe04b47c344e641e1ee378b20addfed13cadd7be06963bfa4811644",
+  "originHash" : "ef429753174ac28f11aed84c5ac419114549bae18006fe896ab2e85f1e3e4ad4",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Tanga/Features/Subscriptions/RevenueCatController.swift
+++ b/Tanga/Features/Subscriptions/RevenueCatController.swift
@@ -11,8 +11,9 @@ class RevenueCatController {
     
     // MARK: Initiliazation
     func initialize() {
+        guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String else {return}
         Purchases.logLevel = .debug
-        Purchases.configure(withAPIKey: "API_KEY_FROM_SECRETS")
+        Purchases.configure(withAPIKey: apiKey)
     }
     
     // MARK: Login and Logout

--- a/Tanga/Info.plist
+++ b/Tanga/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>REVENUECAT_API_KEY</key>
+	<string>${REVENUECAT_API_KEY}</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
In order to not make our API keys public, we have introduced a system based on XCode configuration files that stores our secrets. Xcode automatically merges keys from .xcconfig (configuration file) into the app’s Info.plist at build time.

Resources
- https://medium.com/@gizemturker/ensuring-security-for-secrets-in-ios-app-ff4a25c533a1 (this one is a bit confusing)
- https://stackoverflow.com/questions/24501288/getting-version-and-build-information-with-swift

<img width="765" alt="Screenshot 2025-01-25 at 12 55 39 PM" src="https://github.com/user-attachments/assets/b5e6d6c5-e07b-4b8a-bb6f-0ba725ba08f6" />
